### PR TITLE
Removed dependency on pr2-bios-bmc-images

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.7.2
 
 Package: pr2-installer
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, dnsmasq, atftpd, syslinux, pr2-bios-bmc-images, python-pexpect, apache2, reprepro
+Depends: ${shlibs:Depends}, ${misc:Depends}, dnsmasq, atftpd, syslinux, python-pexpect, apache2, reprepro
 Description: Allows the basestation to install the pr2
 Provides: ${diverted-files}, pr2-basestation
 Conflicts: ${diverted-files}, apparmor


### PR DESCRIPTION
this is not being used because these bios images were for older computers. New bios.